### PR TITLE
NGコマンドの文字列処理の方法を変更

### DIFF
--- a/src/org/mineap/nndd/player/NGListManager.as
+++ b/src/org/mineap/nndd/player/NGListManager.as
@@ -248,7 +248,7 @@ package org.mineap.nndd.player
 			//NGコマンドの文字列と一致するか？（"ALL"と無関係に比較する）　2017/09/21
 			for each(var ngCommand:String in ngCommandList){
 				// NGコマンド文字列とコマンド文字列として正規表現を使い比較、一致したらNGコマンド処理　2017/09/21
-				if(Command2.match(ngCommand)){
+				if(Command2.match("\\b" + ngCommand + "\\b")){
 					return true;
 				}
 			}

--- a/src/org/mineap/nndd/player/NGListManager.as
+++ b/src/org/mineap/nndd/player/NGListManager.as
@@ -209,11 +209,8 @@ package org.mineap.nndd.player
 			}
 			
 			//　コマンドの文字列を大文字化し分割
-			var array:Array = command.toUpperCase().split(" ");
-			
-			//コメントのコマンド文字を大文字に変換　2017/09/28
-			var Command2:String = command.toUpperCase();
-			
+			var commands:Array = command.toUpperCase().split(" ");
+						
 			/**　大幅な修正、この処理を　refreshNgMap　に移動　2017/09/27
 			var isAll:Boolean = false;
 			
@@ -227,7 +224,7 @@ package org.mineap.nndd.player
 			
 			//NGコマンドに"ALL"が指定されていた場合、"184"などのコマンドかどうかのチェックに移動する　2017/09/28
 			if (ngCommandAll) {
-				for each(var com:String in array) {
+				for each(var com:String in commands) {
 					// 184、iPhone、docomo以外のコメントを見つけたらこのコマンドはNG
 					// DEVICE:3DS、DEVICE:WIIU、DEVICE:SWITCH を追加　2017/09/21
 					if ("184" != com && "IPHONE" != com && "DOCOMO" != com && "DEVICE:3DS" != com && "DEVICE:WIIU" != com && "DEVICE:SWITCH" != com) {
@@ -247,8 +244,17 @@ package org.mineap.nndd.player
 			}
 			//NGコマンドの文字列と一致するか？（"ALL"と無関係に比較する）　2017/09/21
 			for each(var ngCommand:String in ngCommandList){
-				// NGコマンド文字列とコマンド文字列として正規表現を使い比較、一致したらNGコマンド処理　2017/09/21
-				if(Command2.match("\\b" + ngCommand + "\\b")){
+				var ngCommands: Array = ngCommand.split(" ");
+				var status: Boolean = true;
+				
+				for each (var ngItem: String in ngCommands) {
+					if (commands.indexOf(ngItem) === -1) {
+						status = false;
+						break;
+					}
+				}
+				
+				if (status) {
 					return true;
 				}
 			}


### PR DESCRIPTION
前のPRの停止ありがとうございます
今回は速度はほんの少し落ちてる気がする程度で済んでいます
あと、NGコマンドの文字処理にsearch()を使用することで正規表現に対応させました

変更点としては下記のようになります
NGListManagerの最初の方に　ngCommandAll（ALL用フラグ）　ngCommandList（NGコマンドリスト）　の宣言をしました
refreshNgMap　をかなり変更しました
NGコマンドに"ALL"の文字列があるかどうか確認し、あった場合は　ngCommandAll　にtrueを設定する
NGコマンド文字列を　ngCommandList　に放り込む処理をする
これに伴いNGコマンド文字列は　NgMap　には入れていません
isNgCommand　は　ngCommandAll　にtrueが設定されている場合には"184"などのコマンドを含むかの判断をさせる
"184"コマンドは"DEVICE:3DS"など類似コマンドもあるので、受け取ったコマンドを切り分けてチェックをかけている
その処理が終了した後　ngCommandList　に入っているNGコマンドコマンド文字列とコマンド文字列を正規表現で比較し処理する
正規表現での検索に対応してる事を動作確認済み

という感じに変更しました
大きな変更点の部分は、一応ですが修正前の処理をコメント文にして残すようにしました
前回と同じように、私の変更点には日付を横に書いてあります

処理自体は、処理するコメント数が１万以上まで多くなると、微妙に差が出てる気がしますが
元のプログラムと１秒あるかないかの差の上に、全体的な動画読み込みの中に埋もれてしまうので
今回の処理は問題ないと思います